### PR TITLE
get_line_number: do not adjust addr by relocate offset

### DIFF
--- a/symbols.c
+++ b/symbols.c
@@ -4296,8 +4296,7 @@ get_line_number(ulong addr, char *buf, int reserved)
 	if (module_symbol(addr, NULL, &lm, NULL, 0)) {
 		if (!(lm->mod_flags & MOD_LOAD_SYMS))
 			return(buf);
-	} else if (kt->flags2 & KASLR)
-		addr -= (kt->relocate * -1);
+	}
 
 	if ((lnh = machdep->line_number_hooks)) {
         	name = closest_symbol(addr);


### PR DESCRIPTION
GBD symbol resolution already considers relocation (KASLR) offset.
So, there is no needs to adjust the function address before calling
GDB.

It fixes file name and line number output for 'dis -l' and 'sys -c'
commands.

Signed-off-by: Alexey Makhalov <amakhalov@vmware.com>