### PR TITLE
gdb_set_crash_scope: remove KASLR relocation

### DIFF
--- a/gdb_interface.c
+++ b/gdb_interface.c
@@ -1013,8 +1013,7 @@ gdb_set_crash_scope(ulong vaddr, char *arg)
 					return FALSE;
 				}
 			}
-		} else if (kt->flags2 & KASLR)
-			vaddr -= (kt->relocate * -1);
+		}
 	}
 
 	req->command = GNU_SET_CRASH_BLOCK;


### PR DESCRIPTION
Since gdb-10.2 can resolve KASLR symbol itself, so let's remove the duplicated
KASLR relocation for crash function gdb_set_crash_scope. Otherwise crash will
encounter the following regression:

  $ crash -s 4.18.0-44.el8_with_user_pages/vmcore 4.18.0-44.el8_with_user_pages/vmlinux.gz
  crash: gdb cannot find text block for address: dd_init_queue

Signed-off-by: Tao Liu <ltao@redhat.com>