### PR TITLE
list_source_code: do not adjust addr by relocate offset

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -1484,8 +1484,7 @@ list_source_code(struct gnu_request *req, int count_entered)
 		if (!(lm->mod_flags & MOD_LOAD_SYMS))
 			error(FATAL, "%s: module source code is not available\n", lm->mod_name);
 		get_line_number(req->addr, buf1, FALSE);
-	} else if (kt->flags2 & KASLR)
-		req->addr -= (kt->relocate * -1);
+	}
 
 	sprintf(buf1, "list *0x%lx", req->addr);
 	open_tmpfile();


### PR DESCRIPTION
It fixes 'dis -s' output.

GBD symbol resolution already considers relocation (KASLR) offset.
So, there is no needs to adjust the function address before calling
GDB.
I strongly believe all such places where kernel addresses passed to
the GDB get adjusted to its build-time value can be safely removed.
This is just one more such place.

Signed-off-by: Alexey Makhalov <amakhalov@vmware.com>